### PR TITLE
Fixed windbg concurrency and added missing locks ##debug

### DIFF
--- a/libr/debug/p/debug_windbg.c
+++ b/libr/debug/p/debug_windbg.c
@@ -57,7 +57,7 @@ static RDebugReasonType r_debug_windbg_wait(RDebug *dbg, int pid) {
 	RDebugReasonType reason = R_DEBUG_REASON_UNKNOWN;
 	kd_packet_t *pkt = NULL;
 	kd_stc_64 *stc;
-	r_cons_break_push (windbg_break, wctx);
+	windbg_lock_enter (wctx);
 	for (;;) {
 		void *bed = r_cons_sleep_begin ();
 		int ret = windbg_wait_packet (wctx, KD_PACKET_TYPE_STATE_CHANGE64, &pkt);
@@ -82,7 +82,7 @@ static RDebugReasonType r_debug_windbg_wait(RDebug *dbg, int pid) {
 		}
 		R_FREE (pkt);
 	}
-	r_cons_break_pop ();
+	windbg_lock_leave (wctx);
 	free (pkt);
 	return reason;
 }

--- a/shlr/windbg/windbg.h
+++ b/shlr/windbg/windbg.h
@@ -98,4 +98,7 @@ int windbg_write_at_phys (WindCtx *ctx, const uint8_t *buf, const ut64 offset, c
 bool windbg_va_to_pa (WindCtx *ctx, ut64 va, ut64 *pa);
 bool windbg_break (WindCtx *ctx);
 int windbg_break_read(WindCtx *ctx);
+bool windbg_lock_enter(WindCtx *ctx);
+bool windbg_lock_leave(WindCtx *ctx);
+bool windbg_lock_tryenter(WindCtx *ctx);
 #endif


### PR DESCRIPTION
Previously, windbg_break would freeze waiting on a lock instead of breaking, taks other than wait weren't breakable and read regs would freeze the process while waiting for a mutex.